### PR TITLE
Example compiles; sketch and readme are consistent with other sketches' setup calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ By default, a Timeline comes with enough storage for 10 tweens.  If you want to 
 const int led = 7;
 
 // A value to pass into a tween.
-double value = 20.0;
+float value = 20.0;
 
-TweenDuino *tween;
+TweenDuino::Tween *tween;
 
 void setup() {
     // Tween to 255.0 from the existing value over 10,000 milliseconds (10 secs).
-    tween = TweenDuino::to(value, 10000UL, 255);
+    tween = TweenDuino::Tween::to(value, 10000UL, 255);
     Serial.print("Values: ");
 }
 void loop() {

--- a/examples/single_tween/single_tween.ino
+++ b/examples/single_tween/single_tween.ino
@@ -8,13 +8,13 @@
 const int led = 7;
 
 // A value to pass into a tween.
-double value = 20.0;
+float value = 20.0;
 
-TweenDuino *tween;
+TweenDuino::Tween *tween;
 
 void setup() {
     // Tween to 255.0 from the existing value over 10,000 milliseconds (10 secs).
-    tween = TweenDuino::to(value, 10000UL, 255);
+    tween = TweenDuino::Tween::to(value, 10000UL, 255);
     Serial.print("Values: ");
 }
 void loop() {


### PR DESCRIPTION
The example sketch and README instantiated their `*tweens` as TweenDuino, which led to "does not name a type" errors; and the use of `double value` where the ::to function wants a float led to an implicit cast and then a non-const lvalue error.

This patch makes the Example sketch consistent with the other provided sample sketches, using TweenDuino::Tween for the tween object's type and TweenDuino::Tween::to as the constructor. It also changes the problematic double value to a float.

The example compiles without issue and the README reflects the working syntax.